### PR TITLE
Fix fallback for not unstable (stable) runtime

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -205,7 +205,14 @@ export class Spinner {
   }
 
   updateLines(): void {
-    const columns = Deno.consoleSize(this.#stream.rid)?.columns || 80;
+    let columns = 80;
+
+    try {
+      columns = Deno.consoleSize(this.#stream.rid)?.columns ?? columns;
+    } catch {
+      // Unstable APIs is not enabled, fallback to default
+    }
+
     const fullPrefixText = typeof this.prefix === "string"
       ? this.prefix + "-"
       : "";


### PR DESCRIPTION
Fix fallback for when the runtime does not support unstable APIs. The ["updateLines"](https://github.com/denosaurs/wait/blob/89bfef4/mod.ts#L207) method used ["Deno.consoleSize"](https://doc.deno.land/builtin/unstable#Deno.consoleSize) to check the amount of columns in the terminal. This has been changed to support the stable runtime by using a try-catch statement.

Fixes #8