### PR TITLE
feat(logging.ts, mod.ts): add console interception to stop spinner while logging and resume after logging is done

### DIFF
--- a/examples/logging.ts
+++ b/examples/logging.ts
@@ -1,0 +1,51 @@
+import { wait } from "../mod.ts";
+
+const spinner = wait({ text: "Generating\nterrain", color: "red", interceptConsole: true })
+
+spinner.start();
+
+console.time("test");
+
+setTimeout(() => {
+  console.timeLog("test");
+  console.log("This log message should\nnot be affected by the spinner");
+}, 1000);
+
+setTimeout(() => {
+  spinner.color = "yellow";
+  spinner.text = "Loading dinosaurs";
+  console.table([{ a: 1, b: "Y" }, { a: "Z", b: 2 }]);
+
+
+
+}, 2000);
+
+setTimeout(() => {
+  spinner.color = "blue";
+  spinner.text = "Loading beasts";
+  console.timeEnd("test");
+
+}, 3000);
+
+setTimeout(() => {
+  spinner.color = "blue";
+  spinner.text = "Loading beasts";
+  console.assert(false, "This is an error message");
+  console.dir({ a: 1, b: "Y" });
+  console.dirxml({ a: 1, b: "Y" });
+  console.count("count");
+  console.countReset("count");
+
+
+}, 3500);
+
+
+setTimeout(() => {
+  spinner.succeed("Mesozoic deployed!");
+}, 4000);
+
+
+setTimeout(() => {
+  console.error("byee");
+
+}, 5000);

--- a/examples/logging.ts
+++ b/examples/logging.ts
@@ -1,6 +1,10 @@
 import { wait } from "../mod.ts";
 
-const spinner = wait({ text: "Generating\nterrain", color: "red", interceptConsole: true })
+const spinner = wait({
+  text: "Generating\nterrain",
+  color: "red",
+  interceptConsole: true,
+});
 
 spinner.start();
 
@@ -15,16 +19,12 @@ setTimeout(() => {
   spinner.color = "yellow";
   spinner.text = "Loading dinosaurs";
   console.table([{ a: 1, b: "Y" }, { a: "Z", b: 2 }]);
-
-
-
 }, 2000);
 
 setTimeout(() => {
   spinner.color = "blue";
   spinner.text = "Loading beasts";
   console.timeEnd("test");
-
 }, 3000);
 
 setTimeout(() => {
@@ -35,17 +35,12 @@ setTimeout(() => {
   console.dirxml({ a: 1, b: "Y" });
   console.count("count");
   console.countReset("count");
-
-
 }, 3500);
-
 
 setTimeout(() => {
   spinner.succeed("Mesozoic deployed!");
 }, 4000);
 
-
 setTimeout(() => {
   console.error("byee");
-
 }, 5000);

--- a/mod.ts
+++ b/mod.ts
@@ -44,6 +44,24 @@ export interface PersistOptions {
   text?: string;
 }
 
+export interface Console {
+  log: typeof console.log;
+  warn: typeof console.warn;
+  error: typeof console.error;
+  info: typeof console.info;
+  debug: typeof console.debug;
+  time: typeof console.time;
+  timeEnd: typeof console.timeEnd;
+  trace: typeof console.trace;
+  dir: typeof console.dir;
+  assert: typeof console.assert;
+  count: typeof console.count;
+  countReset: typeof console.countReset;
+  table: typeof console.table;
+  dirxml: typeof console.dirxml;
+  timeLog: typeof console.timeLog;
+}
+
 export function wait(opts: string | SpinnerOptions) {
   if (typeof opts === "string") {
     opts = { text: opts };
@@ -118,7 +136,7 @@ export class Spinner {
   #prefix = "";
 
   #interceptConsole() {
-    const methods = [
+    const methods: (keyof Console)[] = [
       "log",
       "warn",
       "error",
@@ -136,8 +154,8 @@ export class Spinner {
       "timeLog",
     ];
     for (const method of methods) {
-      const original = (console as any)[method];
-      (console as any)[method] = (...args: unknown[]) => {
+      const original = (console as Console)[method];
+      (console as Console)[method] = (...args: unknown[]) => {
         if (this.isSpinning) {
           this.stop();
           this.clear();

--- a/mod.ts
+++ b/mod.ts
@@ -117,9 +117,24 @@ export class Spinner {
   #text = "";
   #prefix = "";
 
-
   #interceptConsole() {
-    const methods = ["log", "warn", "error", "info", "debug", "time", "timeEnd", "trace", "dir", "assert", "count", "countReset", "table", "dirxml", "timeLog"];
+    const methods = [
+      "log",
+      "warn",
+      "error",
+      "info",
+      "debug",
+      "time",
+      "timeEnd",
+      "trace",
+      "dir",
+      "assert",
+      "count",
+      "countReset",
+      "table",
+      "dirxml",
+      "timeLog",
+    ];
     for (const method of methods) {
       const original = (console as any)[method];
       (console as any)[method] = (...args: unknown[]) => {


### PR DESCRIPTION
This change adds a new feature to the spinner module that allows it to intercept console methods and stop the spinner while logging is being done. This is useful to avoid the spinner animation interfering with the logs. After the logging is done, the spinner resumes its animation. The feature is enabled by default but can be disabled by setting the `interceptConsole` option to `false`. The `logging.ts` file is an example of how to use this feature.
